### PR TITLE
Bug-fix in file parsing and passing arguments

### DIFF
--- a/latexdiff-vc
+++ b/latexdiff-vc
@@ -245,7 +245,7 @@ print STDERR "DEBUG: PDF $pdf latexdiff-vc command line: ", join(" ",@ARGV), "\n
 ###exit;
 
 $file2=pop @ARGV;
-( defined($file2) && $file2 =~ /\.(tex|bbl|flt)$/ ) or pod2usage("Must specify at least one tex, bbl or flt file");
+( defined($file2) && $file2 =~ /\.(tex|bbl|flt)$/ && $file2 =~ /^(?!-)/) or pod2usage("Must specify at least one tex, bbl or flt file not starting with -");
 
 if (! $vc && scalar(@revs)>0 ) {
   # have to guess $vc
@@ -318,7 +318,7 @@ if ( scalar(@revs)>0 ) {
 
 @files=($file2);
 while( $file1=pop @ARGV ) {
-  if ( $file1 =~ /\.(tex|bbl|flt)$/ ) {
+  if ( $file1 =~ /\.(tex|bbl|flt)$/ && $file1 =~ /^(?!-)/ ) {
     # $file1 looks like a valid file name and is prepended to file list
     unshift @files, $file1 ;
   } else {


### PR DESCRIPTION
latexdiff-cvs, treats everything ending with .tex as a file.
Some options of latextdiff might require a file i.e. $latexdiff --preamble=diffpreamble.tex old.tex new.tex
This fix excludes files starting with "-" from the file list allowing the argument to be passed correctly to latexdiff

*Failing scenario:
latexdiff-vc --preamble=diffpreamble.tex --git -r HEAD^ main.tex